### PR TITLE
UIPOLICIES-5 include settings pset

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,6 @@
-# Change history for ui-authorization-roles
+# Change history for ui-authorization-policies
 
 ## 1.2.0
 
 * First release.
+* Include `settings.authorization-policies.enabled` permission set. Refs UIPOLICIES-5.

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,10 @@
 # Change history for ui-authorization-policies
 
+## 1.3.0 IN PROGRESS
+
+* Include `settings.authorization-policies.enabled` permission set. Refs UIPOLICIES-5. 
+
 ## 1.2.0
 
 * First release.
-* Include `settings.authorization-policies.enabled` permission set. Refs UIPOLICIES-5.
+

--- a/package.json
+++ b/package.json
@@ -58,6 +58,21 @@
         "subPermissions": [
           "settings.enabled"
         ]
+      },
+      {
+        "permissionName": "ui-authorization-policies.settings.admin",
+        "displayName": "Settings (Authorization policies): Can manage authorization policies",
+        "description": "",
+        "subPermissions": [
+          "settings.authorization-policies.enabled",
+          "policies.item.get",
+          "policies.item.put",
+          "policies.item.delete",
+          "policies.item.post",
+          "policies.collection.get",
+          "policies.collection.post"
+        ],
+        "visible": true
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,15 @@
         "title": "journal"
       }
     ],
-    "permissionSets": []
+    "permissionSets": [
+      {
+        "permissionName": "settings.authorization-policies.enabled",
+        "displayName": "Settings (Authorization policies): display list of settings pages",
+        "subPermissions": [
+          "settings.enabled"
+        ]
+      }
+    ]
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",

--- a/translations/ui-authorization-policies/en.json
+++ b/translations/ui-authorization-policies/en.json
@@ -8,5 +8,7 @@
   "columns.updatedBy": "Updated by",
   "assignedUsers": "Assigned users",
   "assignUnassign": "Assign/Unassign",
-  "generalInformation": "General Information"
+  "generalInformation": "General Information",
+
+  "permission.settings.admin": "Settings (Authorization policies): Can manage authorization policies"
 }

--- a/translations/ui-authorization-policies/en_GB.json
+++ b/translations/ui-authorization-policies/en_GB.json
@@ -8,5 +8,6 @@
     "columns.updatedBy": "Updated by",
     "assignedUsers": "Assigned users",
     "assignUnassign": "Assign/Unassign",
-    "generalInformation": "General Information"
+    "generalInformation": "General Information",
+    "permission.settings.admin": "Settings (Authorization policies): Can manage authorization policies"
 }

--- a/translations/ui-authorization-policies/en_SE.json
+++ b/translations/ui-authorization-policies/en_SE.json
@@ -8,5 +8,6 @@
     "columns.updatedBy": "Updated by",
     "assignedUsers": "Assigned users",
     "assignUnassign": "Assign/Unassign",
-    "generalInformation": "General Information"
+    "generalInformation": "General Information",
+    "permission.settings.admin": "Settings (Authorization policies): Can manage authorization policies"
 }

--- a/translations/ui-authorization-policies/en_US.json
+++ b/translations/ui-authorization-policies/en_US.json
@@ -8,5 +8,6 @@
     "columns.updatedBy": "Updated by",
     "assignedUsers": "Assigned users",
     "assignUnassign": "Assign/Unassign",
-    "generalInformation": "General Information"
+    "generalInformation": "General Information",
+    "permission.settings.admin": "Settings (Authorization policies): Can manage authorization policies"
 }


### PR DESCRIPTION
* Provide the `settings.authorization-policies.enabled` pset that allows stripes to display this module.
* Provide a top-level permission in order to allow access to this application to be assigned to a capability and role.

Refs [UIPOLICIES-5](https://folio-org.atlassian.net/browse/UIPOLICIES-5)