### PR TITLE
UIPOLICIES-6 use correct stripes.home value in package.json

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,10 @@
 # Change history for ui-authorization-roles
 
-## 1.2.0
+## 1.3.0 IN PROGRESS
+
+* Use correct `stripes.home` value in `package.json`. Refs UIPOLICIES-6.
+
+## [1.2.0](https://github.com/folio-org/ui-authorization-policies/tree/v1.2.0) (2024-01-29)
 
 * First release.
+

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     ],
     "displayName": "ui-authorization-policies.meta.title",
     "route": "/authorization-policies",
-    "home": "/autorization-policies",
+    "home": "/authorization-policies",
     "hasSettings": true,
     "queryResource": "query",
     "okapiInterfaces": {
@@ -131,3 +131,4 @@
     "react-router-dom": "^5.2.0"
   }
 }
+


### PR DESCRIPTION
Fix typo: replace `autorization` with `authorization`.

Refs [UIPOLICIES-6](https://folio-org.atlassian.net/browse/UIPOLICIES-6)