### PR TITLE
UIPOLICIES-11 retrieve updated-by user data en masse

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,6 +3,7 @@
 ## 1.3.0 IN PROGRESS
 
 * Server-side query sort (temporary, lacking i18n).
+* Retrieve updated-by user detail en-masse. Refs UIPOLICIES-11.
 
 ## [1.2.1](https://github.com/folio-org/ui-authorization-policies/tree/v1.2.1) (2024-03-05)
 [Full Changelog](https://github.com/folio-org/ui-authorization-policies/compare/v1.2.0...v1.2.1)

--- a/src/hooks/useUsers.js
+++ b/src/hooks/useUsers.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { keyBy } from 'lodash';
+import {
+  useChunkedCQLFetch,
+  useNamespace,
+} from '@folio/stripes/core';
+
+export const chunkedUsersReducer = (data) => {
+  return data.flatMap(d => d.data?.users || []);
+};
+
+const useUsers = (ids) => {
+  const [namespace] = useNamespace({ key: 'users' });
+
+  const { items, isLoading } = useChunkedCQLFetch({
+    endpoint: 'users',
+    ids: ids.filter(Boolean), // remove empty values
+    reduceFunction: chunkedUsersReducer,
+    generateQueryKey: ({ chunkedItem, endpoint }) => {
+      return [namespace, endpoint, chunkedItem];
+    },
+  });
+
+  return {
+    users: keyBy(items, 'id'),
+    isLoading
+  };
+};
+
+export default useUsers;

--- a/src/hooks/useUsers.js
+++ b/src/hooks/useUsers.js
@@ -14,7 +14,7 @@ const useUsers = (ids) => {
 
   const { items, isLoading } = useChunkedCQLFetch({
     endpoint: 'users',
-    ids: ids.filter(Boolean), // remove empty values
+    ids: Array.from(new Set(ids.filter(Boolean))), // dedupe and deempty
     reduceFunction: chunkedUsersReducer,
     generateQueryKey: ({ chunkedItem, endpoint }) => {
       return [namespace, endpoint, chunkedItem];

--- a/src/hooks/useUsers.test.js
+++ b/src/hooks/useUsers.test.js
@@ -1,0 +1,81 @@
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { act, renderHook } from '@folio/jest-config-stripes/testing-library/react';
+import { keyBy } from 'lodash';
+
+import useUsers, { chunkedUsersReducer } from './useUsers';
+
+const userData = {
+  'items': [
+    {
+      'username': 'aapple',
+      'id': 'a1',
+      'active': true,
+      'type': 'staff',
+      'personal': {
+        'lastName': 'Andrea',
+        'firstName': 'Apple',
+        'middleName': 'A'
+      },
+    },
+    {
+      'username': 'bblick',
+      'id': 'b2',
+      'active': true,
+      'type': 'staff',
+      'personal': {
+        'lastName': 'Bethany',
+        'firstName': 'Blick',
+        'middleName': 'B'
+      }
+    }
+  ],
+  'totalRecords': 2,
+  'resultInfo': {
+    'totalRecords': 2
+  }
+};
+
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  useChunkedCQLFetch: () => ({
+    items: userData,
+    isLoading: false,
+  }),
+  useNamespace: () => ['namespace'],
+  useOkapiKy: () => ({
+    get: () => ({
+      items: userData,
+      isLoading: false,
+    })
+  })
+}));
+
+const queryClient = new QueryClient();
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe('useUsers', () => {
+  it('fetches users', async () => {
+    const { result } = renderHook(() => useUsers(['a', 'b']), { wrapper });
+    await act(() => !result.current.isLoading);
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.users).toMatchObject(keyBy(userData.users, 'id'));
+  });
+});
+
+describe('chunkedUsersReducer', () => {
+  it('assembles chunks', () => {
+    const list = [
+      { data: { users: [1, 2, 3] } },
+      { data: { users: [4, 5, 6] } },
+    ];
+
+    const result = chunkedUsersReducer(list);
+    expect(result.length).toBe(6);
+  });
+});
+

--- a/src/settings/components/PolicyDetails/PolicyDetails.js
+++ b/src/settings/components/PolicyDetails/PolicyDetails.js
@@ -9,11 +9,10 @@ import {
   AccordionStatus,
   Pane,
   KeyValue,
-  MetaSection,
   NoValue
 } from '@folio/stripes/components';
 
-import { UserName } from '@folio/stripes/smart-components';
+import { ViewMetaData } from '@folio/stripes/smart-components';
 import { useStripes } from '@folio/stripes/core';
 
 import css from '../../style.css';
@@ -21,7 +20,7 @@ import css from '../../style.css';
 const PolicyDetails = ({ policy, onClose }) => {
   const { connect } = useStripes();
 
-  const ConnectedUserName = connect(UserName);
+  const ConnectedViewMetaData = connect(ViewMetaData);
 
   return (
     <Pane
@@ -40,16 +39,11 @@ const PolicyDetails = ({ policy, onClose }) => {
               <FormattedMessage id="ui-authorization-policies.generalInformation" />
             }
           >
-            <MetaSection
+            <ConnectedViewMetaData
               id="policyMetadataId"
               contentId="policyMetadata"
               headingLevel={4}
-              createdDate={policy.metadata?.createdDate}
-              lastUpdatedDate={policy.metadata?.modifiedDate}
-              lastUpdatedBy={
-                <ConnectedUserName id={policy.metadata?.modifiedBy} />
-              }
-              createdBy={<ConnectedUserName id={policy.metadata?.createdBy} />}
+              metadata={policy.metadata}
             />
             <KeyValue
               data-testid="policy-name"

--- a/src/settings/components/SettingsPage/SettingsPage.js
+++ b/src/settings/components/SettingsPage/SettingsPage.js
@@ -41,7 +41,7 @@ const SettingsPage = () => {
   );
 
   const { policies, isLoading, refetch } = useAuthorizationPolicies({ searchTerm });
-  const { users } = useUsers(policies.map(i => i.metadata.modifiedBy));
+  const { users } = useUsers(policies.map(i => i.metadata.updatedByUserId));
 
   const handleSearchSubmit = (event) => {
     event.preventDefault();
@@ -50,11 +50,11 @@ const SettingsPage = () => {
 
   const resultsFormatter = {
     name: (item) => <TextLink>{item.name}</TextLink>,
-    updatedBy: (item) => (item.metadata.modifiedBy ? getFullName(users[item.metadata.modifiedBy]) : (
+    updatedBy: (item) => (item.metadata.updatedByUserId ? getFullName(users[item.metadata.updatedByUserId]) : (
       <NoValue />
     )),
-    updated: (item) => (item.metadata.modifiedDate ? (
-      <FormattedDate value={item.metadata.modifiedDate} />
+    updated: (item) => (item.metadata.updatedDate ? (
+      <FormattedDate value={item.metadata.updatedDate} />
     ) : (
       <NoValue />
     )),

--- a/src/settings/components/SettingsPage/SettingsPage.js
+++ b/src/settings/components/SettingsPage/SettingsPage.js
@@ -4,18 +4,19 @@ import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedDate } from 'react-intl';
 
 import {
+  Button,
+  MultiColumnList,
+  NoValue,
   Pane,
   PaneHeader,
-  Paneset,
-  Button,
   PaneMenu,
-  MultiColumnList,
+  Paneset,
   TextLink,
 } from '@folio/stripes/components';
-import { useStripes } from '@folio/stripes/core';
-import { UserName } from '@folio/stripes/smart-components';
+import { getFullName } from '@folio/stripes/util';
 
 import useAuthorizationPolicies from '../../../hooks/useAuthorizationPolicies';
+import useUsers from '../../../hooks/useUsers';
 import { SearchForm } from '../SearchForm';
 import { PolicyDetails } from '../PolicyDetails';
 
@@ -31,10 +32,6 @@ const SettingsPage = () => {
 
   const onRowClick = (_event, row) => setSelectedRow(row);
 
-  const { connect } = useStripes();
-
-  const ConnectedUserName = connect(UserName);
-
   const lastMenu = (
     <PaneMenu>
       <Button buttonStyle="primary" marginBottom0>
@@ -44,6 +41,7 @@ const SettingsPage = () => {
   );
 
   const { policies, isLoading, refetch } = useAuthorizationPolicies({ searchTerm });
+  const { users } = useUsers(policies.map(i => i.metadata.modifiedBy));
 
   const handleSearchSubmit = (event) => {
     event.preventDefault();
@@ -52,17 +50,13 @@ const SettingsPage = () => {
 
   const resultsFormatter = {
     name: (item) => <TextLink>{item.name}</TextLink>,
-    updatedBy: (item) => (item.metadata.modifiedBy ? (
-      <TextLink>
-        <ConnectedUserName id={item.metadata.modifiedBy} />
-      </TextLink>
-    ) : (
-      '-'
+    updatedBy: (item) => (item.metadata.modifiedBy ? getFullName(users[item.metadata.modifiedBy]) : (
+      <NoValue />
     )),
     updated: (item) => (item.metadata.modifiedDate ? (
       <FormattedDate value={item.metadata.modifiedDate} />
     ) : (
-      '-'
+      <NoValue />
     )),
   };
 

--- a/src/settings/components/SettingsPage/SettingsPage.test.js
+++ b/src/settings/components/SettingsPage/SettingsPage.test.js
@@ -3,7 +3,7 @@ import { renderWithIntl } from '@folio/stripes-erm-testing';
 
 import { cleanup } from '@folio/jest-config-stripes/testing-library/react';
 import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
-import { useChunkedCQLFetch, useNamespace } from '@folio/stripes/core';
+// import { useChunkedCQLFetch, useNamespace } from '@folio/stripes/core';
 
 import SettingsPage from './SettingsPage';
 import translationsProperties from '../../../../test/helpers/translationsProperties';
@@ -20,7 +20,7 @@ jest.mock('../../../hooks/useAuthorizationPolicies', () => {
           name: 'Test Policy',
           description: 'policy description in free form',
           metadata: {
-            modifiedDate: '2023-03-14T13:11:59.601+00:00',
+            updatedDate: '2023-03-14T13:11:59.601+00:00',
           },
         },
       ],

--- a/src/settings/components/SettingsPage/SettingsPage.test.js
+++ b/src/settings/components/SettingsPage/SettingsPage.test.js
@@ -3,6 +3,8 @@ import { renderWithIntl } from '@folio/stripes-erm-testing';
 
 import { cleanup } from '@folio/jest-config-stripes/testing-library/react';
 import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+import { useChunkedCQLFetch, useNamespace } from '@folio/stripes/core';
+
 import SettingsPage from './SettingsPage';
 import translationsProperties from '../../../../test/helpers/translationsProperties';
 
@@ -26,11 +28,23 @@ jest.mock('../../../hooks/useAuthorizationPolicies', () => {
   };
 });
 
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  useChunkedCQLFetch: () => ({
+    items: [],
+    isLoading: false,
+  }),
+  useNamespace: () => ['namespace'],
+}));
+
 jest.mock('../PolicyDetails/PolicyDetails', () => () => (
   <div data-testid="mock-policy-details">Policy details pane</div>
 ));
 
 describe('SettingsPage', () => {
+  beforeEach(() => {
+  });
+
   afterEach(() => {
     cleanup();
   });


### PR DESCRIPTION
Aggregate item metadata into a single list and retrieve user records
en-masse instead of one-by-one.

Refs [UIPOLICIES-11](https://folio-org.atlassian.net/issues/UIPOLICIES-11)