### PR TITLE
UIPOLICIES-21: use params to set current policy id in url. Fix jest-axe errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@folio/stripes-testing": "^4.2.0",
     "graphql": "^16.0.0",
     "moment": "^2.22.2",
+    "history": "^4.10.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intl": "^6.4.4",

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,6 +1,8 @@
 import { render } from '@folio/jest-config-stripes/testing-library/react';
 import { useIntlKeyStore } from '@k-int/stripes-kint-components';
 
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { MemoryRouter } from 'react-router-dom';
 import App from '.';
 
 jest.mock('@k-int/stripes-kint-components', () => ({
@@ -16,14 +18,28 @@ jest.mock('./settings', () => ({
     )),
 }));
 
+const queryClient = new QueryClient();
+
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter
+      initialEntries={[{
+        pathname: '/settings',
+      }]}
+    >
+      {children}
+    </MemoryRouter>
+  </QueryClientProvider>
+);
+
 describe('App component', () => {
   it('calls the addKey of useIntlKeyStore function with the correct namespace', () => {
-    render(<App />);
+    render(<App match={{ path:'/settings' }} />, { wrapper });
     expect(useIntlKeyStore()).toHaveBeenCalledWith('ui-authorization-policies');
   });
 
   it('renders settings page', () => {
-    const { getByTestId } = render(<App />);
+    const { getByTestId } = render(<App match={{ path:'/settings' }} />, { wrapper });
     expect(getByTestId('mocked-settings-page')).toBeInTheDocument();
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import { Suspense } from 'react';
-
 import { useIntlKeyStore } from '@k-int/stripes-kint-components';
-
+import { Switch, Route } from 'react-router-dom';
 import Settings from './settings';
 
 const App = (props) => {
@@ -10,7 +9,9 @@ const App = (props) => {
 
   return (
     <Suspense>
-      <Settings {...props} />
+      <Switch>
+        <Route path={`${props.match.path}/:id?`} render={() => <Settings {...props} />} />
+      </Switch>
     </Suspense>
   );
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import PropTypes from 'prop-types';
 import { useIntlKeyStore } from '@k-int/stripes-kint-components';
 import { Switch, Route } from 'react-router-dom';
 import Settings from './settings';
@@ -14,6 +15,12 @@ const App = (props) => {
       </Switch>
     </Suspense>
   );
+};
+
+App.propTypes = {
+  match: PropTypes.shape({
+    path: PropTypes.string.isRequired,
+  })
 };
 
 export default App;

--- a/src/settings/SettingsPage/SettingsPage.js
+++ b/src/settings/SettingsPage/SettingsPage.js
@@ -17,6 +17,8 @@ import {
   Paneset,
 } from '@folio/stripes/components';
 
+import { useParams } from 'react-router-dom';
+import { useHistory } from 'react-router';
 import {
   COLUMN_MAPPING,
   getResultsFormatter,
@@ -31,11 +33,10 @@ const propTypes = {
   tenantId: PropTypes.string,
 };
 
-const SettingsPage = ({ affiliationSelectionComponent, tenantId }) => {
+const SettingsPage = ({ affiliationSelectionComponent, tenantId, match:{ path } }) => {
+  const { id: policyId } = useParams();
+  const history = useHistory();
   const [searchTerm, setSearchTerm] = useState('');
-  const [selectedRow, setSelectedRow] = useState(null);
-
-  const onRowClick = (_event, row) => setSelectedRow(row);
 
   const lastMenu = (
     <PaneMenu>
@@ -57,8 +58,9 @@ const SettingsPage = ({ affiliationSelectionComponent, tenantId }) => {
     refetch();
   };
 
-  const formatter = useMemo(() => getResultsFormatter({ users }), [users]);
+  const formatter = useMemo(() => getResultsFormatter({ users, path }), [users, path]);
 
+  const selectedPolicy = useMemo(() => policies.find(i => i.id === policyId), [policies, policyId]);
   return (
     <Paneset>
       <Pane
@@ -83,13 +85,11 @@ const SettingsPage = ({ affiliationSelectionComponent, tenantId }) => {
           columnMapping={COLUMN_MAPPING}
           contentData={policies}
           formatter={formatter}
-          selectedRow={selectedRow}
-          onRowClick={onRowClick}
           loading={isLoading}
           visibleColumns={VISIBLE_COLUMNS}
         />
       </Pane>
-      {selectedRow && <PolicyDetails policy={selectedRow} onClose={() => setSelectedRow(null)} />}
+      {selectedPolicy && <PolicyDetails policy={selectedPolicy} onClose={() => history.push(path)} />}
     </Paneset>
   );
 };

--- a/src/settings/SettingsPage/constanta.js
+++ b/src/settings/SettingsPage/constanta.js
@@ -24,8 +24,8 @@ export const VISIBLE_COLUMNS = [
   COLUMN_NAMES.updatedBy,
 ];
 
-export const getResultsFormatter = ({ users }) => ({
-  [COLUMN_NAMES.name]: (item) => <TextLink>{item.name}</TextLink>,
+export const getResultsFormatter = ({ users, path }) => ({
+  [COLUMN_NAMES.name]: (item) => <TextLink to={`${path}/${item.id}`}>{item.name}</TextLink>,
   [COLUMN_NAMES.updatedBy]: (item) => (item.metadata.updatedByUserId
     ? getFullName(users[item.metadata.updatedByUserId])
     : <NoValue />

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,2 +1,3 @@
 // eslint-disable-next-line import/prefer-default-export
 export { default as translationsProperties } from './translationsProperties';
+export { default as renderWithRouter } from './renderWithRouter';

--- a/test/helpers/renderWithRouter.js
+++ b/test/helpers/renderWithRouter.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { IntlProvider } from 'react-intl';
+
+const history = createMemoryHistory();
+const renderWithRouter = children => (
+  <Router history={history}>
+    <IntlProvider
+      locale="en"
+      messages={{}}
+    >
+      {children}
+    </IntlProvider>
+  </Router>
+);
+
+export default renderWithRouter;


### PR DESCRIPTION
The PR includes similar changes as for [UIROLES-46](https://folio-org.atlassian.net/browse/UIROLES-46).
Refs [UIPOLICIES-21](https://folio-org.atlassian.net/browse/UIPOLICIES-21) - jest-axe reports a11y warnings
