### PR TITLE
UIPOLICIES-26 include universal read-only permissions

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,7 @@
 
 * *BREAKING* migrate react-intl to v7. Refs UIPOLICIES-22.
 * *BREAKING* migrate stripes dependencies to their Sunflower versions. Refs UIPOLICIES-23.
+* Include universal read-only permissions. Refs UIPOLICIES-26.
 
 ## 1.3.0 IN PROGRESS
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
         "permissionName": "settings.authorization-policies.enabled",
         "displayName": "Settings (Authorization policies): display list of settings pages",
         "subPermissions": [
-          "settings.enabled"
+          "settings.enabled",
+          "stripes-core.settings.read"
         ]
       },
       {


### PR DESCRIPTION
Use stripes-core's univeral read-only permission set so users who _only_ have access to this app have the necessary permissions to execute API queries during session init.

Refs [UIPOLICIES-26](https://folio-org.atlassian.net/browse/UIPOLICIES-26), [STRIPES-997](https://folio-org.atlassian.net/browse/STRIPES-997)